### PR TITLE
Fix build issue with newest gdlib issuing warnings on gdlib-config

### DIFF
--- a/util.sh
+++ b/util.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 
-LIST=`gdlib-config --features`
+LIST=`gdlib-config --features 2>/dev/null`
 PRESENT=0
 
 for i in $LIST; do


### PR DESCRIPTION
On MacOS (probably linux as well), with gdlib 2.2.1 (latest), `gdlib-config` now shows the following warning:

```bash
> gdlib-config --features
gdlib-config: warning: this script is deprecated; please use the pkg-config file instead.
GD_GIF GD_GIFANIM GD_OPENPOLYGON GD_ZLIB GD_PNG GD_FREETYPE GD_FONTCONFIG GD_JPEG GD_TIFF GD_WEBP
```

This breaks the `util.sh` parsing and the build fails. 
I have redirected warnings to /dev/null in order to prevent this extra text from being processed.
(I haven't found a way to use `pkg-config gdlib` to get the same output..)