### PR TITLE
add img.destroy to examples, add memory leak test

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,9 @@ img.savePng('output.png', 1, function(err) {
     throw err;
   }
 });
+
+// Destroy image to clean memory
+img.destroy();
 ```
 
 __Asynchronous__ example of drawing a red lined hexagon on a black background:
@@ -110,6 +113,7 @@ gd.createTrueColor(200,200, function(error, img) {
   img.setThickness(4);
   img.polygon(points, 0xff0000);
   img.bmp('test1.bmp', 0);
+  img.destroy();
 });
 ```
 
@@ -125,6 +129,7 @@ gd.openFile('/path/to/file.jpg', function(err, img) {
   img.emboss();
   img.brightness(75);
   img.saveFile('/path/to/newFile.bmp', function(err) {
+    img.destroy();
     if (err) {
       throw err;
     }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "bugs": "https://github.com/y-a-v-a/node-gd/issues",
   "scripts": {
     "pretest": "node-gyp rebuild",
-    "test": "mocha --reporter spec --bail --ui bdd --colors test/test.js",
+    "test": "mocha --expose-gc --reporter spec --bail --ui bdd --colors test/test.js",
     "install": "node-gyp rebuild"
   },
   "repository": {

--- a/test/test.js
+++ b/test/test.js
@@ -791,4 +791,46 @@ describe('Node.js GD Graphics Library', function() {
       });
     });
   });
+
+  describe('section Memory leaks', function() {
+    it('sync openJpeg and then destroy doesn\'t leak', function(done) {
+      var s;
+      var oldMem;
+      var newMem;
+      var iterations = 50;
+      s = source + 'input.jpg';
+      if(global.gc) {
+        // iterate image loading to memory and destroying it, GC and new stats
+        for (var i = 0; i < iterations; i++) {
+          var img = gd.openJpeg(s);
+          img.destroy();
+          global.gc();
+        };
+        // run gc multiple times to ensure deep clean
+        for(var i = 0; i < 10; i++) {
+          global.gc();
+        }
+        oldMem = process.memoryUsage();
+        // iterate image loading to memory and destroying it, GC and new stats
+        for (var i = 0; i < iterations; i++) {
+          var img = gd.openJpeg(s);
+          img.destroy();
+          global.gc();
+        };
+        // run gc multiple times to ensure deep clean
+        for(var i = 0; i < 10; i++) {
+          global.gc();
+        }
+        newMem = process.memoryUsage();
+        if((newMem.heapUsed > (oldMem.heapUsed + 100*1024)) || (newMem.rss > (oldMem.rss + 100*1024)) || (newMem.heapTotal > (oldMem.heapTotal + 100*1024))){ // consider quadruple the image in the memory size be ok
+          done("Memory leaks.\nrss delta: " + (newMem.rss - oldMem.rss) + "\nheapTotal delta: " + (newMem.heapTotal - oldMem.heapTotal) + "\nheapUsed delta: " + (newMem.heapUsed - oldMem.heapUsed));
+        }else{
+          done();
+        }
+      }else{
+        done();
+      }
+    });
+  });
+
 });


### PR DESCRIPTION
There were no img.destroy in examples.
It took time to find out what and why leaks.

So, I added destroy to examples and found out what to do during test implementation.