### PR TITLE
Node6 mem leak test gc scavenge mode to pass tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ node_js:
   - "0.10"
   - "4.3"
   - "5.6"
+  - "6"
 
 sudo: required
 

--- a/test/test.js
+++ b/test/test.js
@@ -796,7 +796,7 @@ describe('Node.js GD Graphics Library', function() {
       var s;
       var oldMem;
       var newMem;
-      var iterations = 1250;
+      var iterations = 150;
       s = source + 'input.jpg';
       if(global.gc) {
         // iterate image loading to memory and destroying it, GC and new stats

--- a/test/test.js
+++ b/test/test.js
@@ -796,30 +796,24 @@ describe('Node.js GD Graphics Library', function() {
       var s;
       var oldMem;
       var newMem;
-      var iterations = 50;
+      var iterations = 1250;
       s = source + 'input.jpg';
       if(global.gc) {
         // iterate image loading to memory and destroying it, GC and new stats
         for (var i = 0; i < iterations; i++) {
           var img = gd.openJpeg(s);
           img.destroy();
-          global.gc();
+          global.gc(1); // GC scavenge mode
         };
-        // run gc multiple times to ensure deep clean
-        for(var i = 0; i < 10; i++) {
-          global.gc();
-        }
+        global.gc(1); // GC scavenge mode
         oldMem = process.memoryUsage();
         // iterate image loading to memory and destroying it, GC and new stats
         for (var i = 0; i < iterations; i++) {
           var img = gd.openJpeg(s);
           img.destroy();
-          global.gc();
+          global.gc(1); // GC scavenge mode
         };
-        // run gc multiple times to ensure deep clean
-        for(var i = 0; i < 10; i++) {
-          global.gc();
-        }
+        global.gc(1); // GC scavenge mode
         newMem = process.memoryUsage();
         if((newMem.heapUsed > (oldMem.heapUsed + 100*1024)) || (newMem.rss > (oldMem.rss + 100*1024)) || (newMem.heapTotal > (oldMem.heapTotal + 100*1024))){ // consider quadruple the image in the memory size be ok
             var error = new Error("Memory leaks.\nrss delta: " + (newMem.rss - oldMem.rss) + "\nheapTotal delta: " + (newMem.heapTotal - oldMem.heapTotal) + "\nheapUsed delta: " + (newMem.heapUsed - oldMem.heapUsed));

--- a/test/test.js
+++ b/test/test.js
@@ -805,7 +805,12 @@ describe('Node.js GD Graphics Library', function() {
           img.destroy();
           global.gc(1); // GC scavenge mode
         };
-        global.gc(1); // GC scavenge mode
+        for (var i = 0; i < 10; i++) {
+          global.gc(1); // GC scavenge mode
+        }
+        for (var i = 0; i < 10; i++) {
+          global.gc();
+        }
         oldMem = process.memoryUsage();
         // iterate image loading to memory and destroying it, GC and new stats
         for (var i = 0; i < iterations; i++) {
@@ -813,7 +818,12 @@ describe('Node.js GD Graphics Library', function() {
           img.destroy();
           global.gc(1); // GC scavenge mode
         };
-        global.gc(1); // GC scavenge mode
+        for (var i = 0; i < 10; i++) {
+          global.gc(1); // GC scavenge mode
+        }
+        for (var i = 0; i < 10; i++) {
+          global.gc();
+        }
         newMem = process.memoryUsage();
         if((newMem.heapUsed > (oldMem.heapUsed + 100*1024)) || (newMem.rss > (oldMem.rss + 100*1024)) || (newMem.heapTotal > (oldMem.heapTotal + 100*1024))){ // consider quadruple the image in the memory size be ok
             var error = new Error("Memory leaks.\nrss delta: " + (newMem.rss - oldMem.rss) + "\nheapTotal delta: " + (newMem.heapTotal - oldMem.heapTotal) + "\nheapUsed delta: " + (newMem.heapUsed - oldMem.heapUsed));


### PR DESCRIPTION
Travis result: https://travis-ci.org/sheershoff/node-gd/builds/140474033

As discussed in #28, node v6 doesn't trigger deep memory clean on several global.gc() calls, so the tests fail.

Haven't found in docs, just tried global.gc(1) with --trace_gc option. Seems like this triggers the scavenge mode. However on node versions 0.* this seem to have no effect on the mode, so several calls to gc() are needed to ensure the deep clean. I'll do the research and make a post on my blog. :-)