### PR TITLE
print error stack before exit when error on loading addon

### DIFF
--- a/js/node-gd.js
+++ b/js/node-gd.js
@@ -104,7 +104,8 @@ try {
   try {
     bindings = require(libPaths.shift());
   } catch (e) {
-    console.log('Unable to find addon node_gd.node in build directory.');
+    console.error('Unable to load addon node_gd.node in build directory.');
+    console.error(e.stack || e);
     process.exit(1);
   }
 }


### PR DESCRIPTION
In case like when I upgrade GCC from 4.x to 5.x, the build is OK, and `node_gd.node` is there, but
direct require will result a error like `/usr/lib64/libstdc++.so.6: version `GLIBCXX_3.4.21' not found`

And node-gd tells that `can't find node_gd.node`, that confuses me, and hard to trouble shooting.
Print the error stack before exit is more nicer.