### PR TITLE
fix node 12 compatibility fixes #70

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ node_js:
   - "8"
   - "10"
   - "11"
+  - "12"
 
 sudo: required
 

--- a/cpp/createworker.cc
+++ b/cpp/createworker.cc
@@ -37,7 +37,7 @@ class CreateWorker : public Nan::AsyncWorker {
       const int _argc = 1;
       v8::Local<v8::Value> _argv[_argc] = {Nan::New<v8::External>(image)};
       v8::Local<v8::FunctionTemplate> func = Nan::New(Gd::Image::constructor);
-      v8::MaybeLocal<v8::Object> _image = Nan::NewInstance(func->GetFunction(), _argc, _argv);
+      v8::MaybeLocal<v8::Object> _image = Nan::NewInstance(func->GetFunction(Nan::GetCurrentContext()).ToLocalChecked(), _argc, _argv);
 
       const int argc = 2;
       v8::Local<v8::Value> argv[argc] = {


### PR DESCRIPTION
Hey!

I was able to get this library compiled and work with NodeJS 12. The issue was the new node wants context argument to be passed on certain functions (previously optional), the definiton of context is described on Context-aware addons of NodeJS documentation here: https://nodejs.org/api/addons.html

> There are environments in which Node.js addons may need to be loaded multiple times in multiple contexts. For example, the Electron runtime runs multiple instances of Node.js in a single process. Each instance will have its own require() cache, and thus each instance will need a native addon to behave correctly when loaded via require(). From the addon's perspective, this means that it must support multiple initializations.

The current version passes the tests on NodeJS 12 and I wrote a demo script to place a simple text on existing PNG file - it worked as well.

However, I didn't tested this with previous versions of NodeJS which I am asking help from the maintainers (it might work out of the box as well).  

Here are some logs:

```
[buraktamturk:~/projects/node-gd] node12 2s ± node --version
v12.5.0
[buraktamturk:~/projects/node-gd] node12 ± npm run test

> node-gd@1.5.4 pretest /Users/buraktamturk/projects/node-gd
> node-gyp build

make: Nothing to be done for `all'.

> node-gd@1.5.4 test /Users/buraktamturk/projects/node-gd
> mocha --reporter spec --bail --ui bdd --colors -- test/*.test.js



Built on top of GD version: 2.2.5


  Creating images containing text
    ✓ can create an image with text
    ✓ can create a truecolor image with text
    ✓ can return the coordinates of the bounding box of a string
    ✓ can return the coordinates of the bounding box of a string using a specific function
    ✓ throws an error when gd.Image#stringFTEx() does not receive an object
    ✓ can consume an object with font extras
    ✓ can set the dpi of an image using a font extras object
    ✓ can set the linespacing of text in an image using a font extras object
    ✓ can request the kerning table of text in an image using a font extras object
    ✓ can disable the use of kerning of text in an image using a font extras object
    ✓ can return the font path using font extras
    ✓ can use a specified charmap to render a font with font extras
    ✓ throws an error when an unknown charmap is given with font extras
    ✓ returns an array of coordinates of the bounding box when an 8th boolean parameter is given to gd.Image#stringFTEx
    ✓ can put text on a circle (45ms)

  Creating a paletted image
    ✓ can be done synchronously
    ✓ throws an Error when too few arguments are supplied
    ✓ throws an Error when argument is not a Number - NaN
    ✓ throws an Error when argument is not a Number - Infinity
    ✓ throws an TypeError when the first argument if of wrong type
    ✓ throws an TypeError when the second argument if of wrong type
    ✓ can be done asynchronously.
    ✓ throws a RangeError when the width parameter is 0
    ✓ throws a RangeError when the height parameter is 0
    ✓ throws a RangeError when the height parameter is a negative value
    ✓ throws an Error when creating an image without width and height - gd.create()
    ✓ throws a Error when the height parameter is 0 async
    ✓ returns an object containing basic information about the created image
    ✓ returns an object containing basic information about the created image async

  Create a true color image
    ✓ can be done synchronously.
    ✓ throws an Error when too few arguments are supplied
    ✓ throws an TypeError when the first argument if of wrong type
    ✓ throws an TypeError when the second argument if of wrong type
    ✓ can be done asynchronously.
    ✓ throws a RangeError when the width parameter is 0
    ✓ throws a RangeError when the height parameter is 0
    ✓ returns an object containing basic information about the created image

  Creating image from String or Buffer
    ✓ should accept a String
    ✓ should accept a Buffer
    ✓ should not accept a Number

  Node.js GD Graphics Library
    ✓ can scale-down (resize) an image
    ✓ can rotate an image
    ✓ can convert to grayscale
    ✓ can add gaussian blur to an image
    ✓ can negate an image
    ✓ can change brightness of an image
    ✓ can change contrast of an image
    ✓ can emboss an image
    ✓ can apply selective blur to an image
    ✓ can replace a color to another color
    ✓ can create a truecolor BMP image with text
    ✓ can create a truecolor Tiff image with text
    Version information
      ✓ will return a version number of format x.y.z - gd.getGDVersion()
    GD color functions
      ✓ can return an integer representation of rgb color values
      ✓ can return an integer representation of rgba color values
    From the gd.Image query functions,
      ✓ getBoundsSafe should return 0 if the coordinate [-10, 1000] is checked against the image bounds.
      ✓ getBoundsSafe should return 1 if the coordinate [10, 10] is checked against the image bounds.
      ✓ getTrueColorPixel should return "e6e6e6" when queried for coordinate [10, 10].
      ✓ getTrueColorPixel should return 0 when queried for coordinate [101, 101].
      ✓ imageColorAt should return "be392e" when queried for coordinate [50, 50].
      ✓ imageColorAt should throw an error when queried for coordinate [101, 101].

  Section Querying image information
    ✓ can query true color alpha values of a color
    ✓ can query true color values of a color
    ✓ can query palette color values of a color with alpha
    ✓ can query palette color values of a color
    ✓ can query the color of a pixel within image bounds
    ✓ will throw an error when quering the color of a pixel outside of image bounds

  Section Handling TIFF files
TIFFFetchNormalTag: Warning, Incompatible type for "RichTIFFIPTC"; tag ignored.
    ✓ can open a tiff and save it as a jpg
    ✓ can open a jpg file and save it as a tiff
TIFFFetchNormalTag: Warning, Incompatible type for "RichTIFFIPTC"; tag ignored.
    ✓ can open a tiff and save it as a tiff
TIFFFetchNormalTag: Warning, Incompatible type for "RichTIFFIPTC"; tag ignored.
    ✓ can open a tif and store it in a pointer and save a tiff from the pointer


  71 passing (240ms)
```