### PR TITLE
Fix a typo in the documentation

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -66,7 +66,7 @@ Synchronous version of `gd.create()`.
 
 ### gd.createTrueColorSync(width, height)
 
-Synchronous version of `gd.createCreateTrueColor()`.
+Synchronous version of `gd.createTrueColor()`.
 
 ### gd.openJpeg(path)
 


### PR DESCRIPTION
### DESCRIPTION

Hi guys!
I was reading the doc and I found what I guess is a typo:

`gd.createTrueColorSync` is referenced as sync version of `gd.createCreateTrueColor` method that doesn't exist; 
So... here's the fix 😃 