### PR TITLE
fix marco for SaveHeifWorker

### DIFF
--- a/src/node_gd_workers.cc
+++ b/src/node_gd_workers.cc
@@ -857,7 +857,7 @@ private:
   }
 };
 
-#if HAS_LIBAVIF
+#if HAS_LIBHEIF
 class SaveHeifWorker : public SaveWorker
 {
 public:


### PR DESCRIPTION
The marco `HAS_LIBAVIF` is not for SaveHeifWorker.